### PR TITLE
Fix lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About pydocstyle
 
 Home: https://github.com/PyCQA/pydocstyle
 
-Package license: MIT License
+Package license: MIT
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
 
 about:
   home: https://github.com/PyCQA/pydocstyle
-  license: MIT License
+  license: MIT
   summary: 'Python docstring style checker (formerly pep257)'
   description: |
     pydocstyle is a static analysis tool for checking compliance with Python


### PR DESCRIPTION
Drop "License" from `license` metadata as this is a lint error.