### PR TITLE
Update to version 6.2.2 and remove importlib-metadata dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pydocstyle" %}
-{% set version = "6.2.0" %}
-{% set hash = "b2d280501a4c0d9feeb96e9171dc3f6f7d0064c55270f4c7b1baa18452019fd9" %}
+{% set version = "6.2.2" %}
+{% set hash = "5714e3a96f6ece848a1c35f581e89f3164867733609f0dd8a99f7e7c6b526bdd" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,13 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=3.8
     - poetry-core
 
   run:
-    - python >=3.6
+    - python >=3.8
     - snowballstemmer >=2.2.0
-    - importlib-metadata >=2.0.0,<5.0.0
+    - tomli >=1.2.3
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

- Update minimal required Python to 3.8 to avoid `pip check` and resolution issues with importlib-metadata. 

<!--
Please add any other relevant info below:
-->

Closes #25.